### PR TITLE
Remove clear wizard call from cancel wizzard function

### DIFF
--- a/Example/SimpleWizzard.xcodeproj/project.pbxproj
+++ b/Example/SimpleWizzard.xcodeproj/project.pbxproj
@@ -278,13 +278,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SimpleWizzard_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		14BA47790DC2F379FCADF629 /* [CP] Copy Pods Resources */ = {
@@ -323,9 +326,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-SimpleWizzard_Tests/Pods-SimpleWizzard_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -338,9 +344,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-SimpleWizzard_Example/Pods-SimpleWizzard_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/SimpleWizzard/SimpleWizzard.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SimpleWizzard.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -353,13 +362,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SimpleWizzard_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -505,7 +517,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -521,7 +533,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Example/SimpleWizzard/SampleWizardController.swift
+++ b/Example/SimpleWizzard/SampleWizardController.swift
@@ -15,7 +15,7 @@ class SampleWizardController: SimpleWizardViewController, CancelDelegate {
         super.viewDidLoad()
         
         // Styling
-        self.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
+        self.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
         self.navigationBar.tintColor = UIColor.white
         self.navigationBar.barTintColor = UIColor(red: 51/255, green: 64/255, blue: 189/255, alpha: 1)
         self.navigationBar.barStyle = .black

--- a/Example/SimpleWizzard/SampleWizardController.swift
+++ b/Example/SimpleWizzard/SampleWizardController.swift
@@ -52,6 +52,12 @@ class SampleWizardController: SimpleWizardViewController, CancelDelegate {
     }
     
     func cancel() {
-        self.dismiss(animated: true, completion: nil)
+        let alert = UIAlertController(title: "Alert", message: "Exit from SampleWizzard?", preferredStyle: UIAlertControllerStyle.alert)
+        alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: { action in
+            self.clearWizard()
+            self.dismiss(animated: true, completion: nil)
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        self.present(alert, animated: true, completion: nil)
     }
 }

--- a/SimpleWizzard.podspec
+++ b/SimpleWizzard.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SimpleWizzard'
-  s.version          = '0.1.1'
+  s.version          = '0.1.2'
   s.summary          = 'A library that helps the user to build a Stepper for its form or anything it wants.'
 
 # This description is used to generate tags and improve search results.

--- a/SimpleWizzard/Classes/SimpleWizardViewController.swift
+++ b/SimpleWizzard/Classes/SimpleWizardViewController.swift
@@ -145,7 +145,7 @@ open class SimpleWizardViewController: UINavigationController, StepPageViewContr
          */
     }
     
-    func clearWizard() {
+    public func clearWizard() {
         self.nextButton = nil
         self.prevButton = nil
         self.pageDots = nil
@@ -154,12 +154,11 @@ open class SimpleWizardViewController: UINavigationController, StepPageViewContr
         self.pageViewController?.wizzard = nil
         self.popToRootViewController(animated: true)
         SimpleWizardViewController.wizardInstance = nil
+        self.cancelDelegate = nil
     }
     
-    func cancelWizzard(_ gesture: UITapGestureRecognizer) {
-        self.clearWizard()
+    @objc func cancelWizzard(_ gesture: UITapGestureRecognizer) {
         self.cancelDelegate?.cancel()
-        self.cancelDelegate = nil
     }
     
     func setChildViews(_ childViews: [UIViewController]) {
@@ -193,11 +192,11 @@ open class SimpleWizardViewController: UINavigationController, StepPageViewContr
         self.pageViewController?.goToPrev()
     }
     
-    func prevAction(_ sender: UIButton) {
+    @objc func prevAction(_ sender: UIButton) {
         self.moveDelegate?.verifyPrev()
     }
     
-    func nextAction(_ sender: UIButton) {
+    @objc func nextAction(_ sender: UIButton) {
         if self.pageViewController?.currentViewController == self.pageViewController?.orderedViewControllers?.last {
             if let val = self.moveDelegate?.verifyDone() {
                 if val {


### PR DESCRIPTION
Change to enable the use of confirmation dialogs before exit from the SimpleWizzard. User now needs to call clearWizzard() manually when necessary.

From:
```
    func clearWizard() {
        self.nextButton = nil
        self.prevButton = nil
        self.pageDots = nil
        self.moveDelegate = nil
        self.wrapController = nil
        self.pageViewController?.wizzard = nil
        self.popToRootViewController(animated: true)
        SimpleWizardViewController.wizardInstance = nil
    }
    
    func cancelWizzard(_ gesture: UITapGestureRecognizer) {
        self.clearWizard()
        self.cancelDelegate?.cancel()
        self.cancelDelegate = nil
    }
```

To:
```
    public func clearWizard() {
        self.nextButton = nil
        self.prevButton = nil
        self.pageDots = nil
        self.moveDelegate = nil
        self.wrapController = nil
        self.pageViewController?.wizzard = nil
        self.popToRootViewController(animated: true)
        SimpleWizardViewController.wizardInstance = nil
        self.cancelDelegate = nil
    }
    
    @objc func cancelWizzard(_ gesture: UITapGestureRecognizer) {
        self.cancelDelegate?.cancel()
    }
```

Obs.: @objc attribute was added in all functions used with a #selector. XCode 9.1 refuses to compile without this attribute.